### PR TITLE
Tidied HTML/CSS, fixed system font not being used in Chrome on OSX

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,9 +24,9 @@
   <body>
     <header id="hero-header"></header>
     <div id="hero-explanation">
-      <h1 class="header" id="hero-title">iOS&nbsp;10&nbsp;UI</h1>
+      <h1 id="hero-title">iOS&nbsp;10&nbsp;UI</h1>
       <div class="separator"></div>
-      <h4 class="description" id="hero-description">iOS 10 is here, and we would
+      <h4 id="hero-description">iOS 10 is here, and we would
         like to present you the ultimate kit for it. Get screens, apps, icons,
         effects and much more from the new delightfully designed operating
         system&nbsp;by&nbsp;Apple.</h4>
@@ -39,71 +39,69 @@
       </div>
     </div>
     <div id="parallax-wrapper"></div>
-    <div id="key-points">
-      <div id="key-points-table">
-        <div>
-          <img class="key-point-images" src="resources/icons/symbols_2x.png" />
-          <p class="key-point-explanations"><b>Symbols.</b> Every new UI element
-            uses Sketch's Symbols for easy customisation and re-use.</p>
-        </div>
+    <div id="key-points-table">
+      <div>
+        <img class="key-point-images" src="resources/icons/symbols_2x.png" />
+        <p class="key-point-explanations"><b>Symbols.</b> Every new UI element
+          uses Sketch's Symbols for easy customisation and re-use.</p>
+      </div>
 
-        <div>
-          <img class="key-point-images" src="resources/icons/ui_2x.png" />
-          <p class="key-point-explanations"><b>All-new UI.</b> Designed pixel-perfect
-            to an exhausting amount of detail.</p>
-        </div>
+      <div>
+        <img class="key-point-images" src="resources/icons/ui_2x.png" />
+        <p class="key-point-explanations"><b>All-new UI.</b> Designed pixel-perfect
+          to an exhausting amount of detail.</p>
+      </div>
 
-        <div>
-          <img class="key-point-images" src="resources/icons/templates_2x.png" />
-          <p class="key-point-explanations"><b>Templates.</b> Start designing for
-            iOS 10 with the all-new widgets and notifications templates.</p>
-        </div>
+      <div>
+        <img class="key-point-images" src="resources/icons/templates_2x.png" />
+        <p class="key-point-explanations"><b>Templates.</b> Start designing for
+          iOS 10 with the all-new widgets and notifications templates.</p>
+      </div>
 
-        <div>
-          <img class="key-point-images" src="resources/icons/open_source_2x.png" />
-          <p class="key-point-explanations"><b>Open source.</b> Make tweaks and contribute on <a href="https://github.com/iOS10-KIT/UI">GitHub!</a> Let's make this the standard iOS UI kit.</p>
-        </div>
+      <div>
+        <img class="key-point-images" src="resources/icons/open_source_2x.png" />
+        <p class="key-point-explanations"><b>Open source.</b> Make tweaks and contribute on <a href="https://github.com/iOS10-KIT/UI">GitHub!</a> Let's make this the standard iOS UI kit.</p>
+      </div>
 
-        <div>
-          <img class="key-point-images" src="resources/icons/updates_2x.png" />
-          <p class="key-point-explanations"><b>Updates.</b> Keep the kit up-to-date
-            as soon as new UI changes appear in iOS 10.</p>
-        </div>
+      <div>
+        <img class="key-point-images" src="resources/icons/updates_2x.png" />
+        <p class="key-point-explanations"><b>Updates.</b> Keep the kit up-to-date
+          as soon as new UI changes appear in iOS 10.</p>
+      </div>
 
-        <div>
-          <img class="key-point-images" src="resources/icons/vectorized_2x.png" />
-          <p class="key-point-explanations"><b>Vectorized.</b> Of course, everything
-            in the kit is cleanly scalable and resizeable.</p>
+      <div>
+        <img class="key-point-images" src="resources/icons/vectorized_2x.png" />
+        <p class="key-point-explanations"><b>Vectorized.</b> Of course, everything
+          in the kit is cleanly scalable and resizeable.</p>
+      </div>
+    </div>
+    <footer>
+      <div id="footer-wrapper">
+        <img class="footer-images" id="footer-image-left"
+        src="resources/music_screen.png" />
+        <img class="footer-images" id="footer-image-right"
+        src="resources/health_screen.png" />
+
+        <div id="credit-container">
+          <table id="share-table">
+            <tr>
+              <td><a href="https://plus.google.com/share?url=https://puzzles.design" target="_blank">
+                <img class="share-images" src="resources/google_share.png" /></a></td>
+              <td>
+              <a href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fpuzzles.design%2F&ref_src=twsrc%5Etfw&text=Enjoying%20the%20iOS%2010%20UI%20Kit!&tw_p=tweetbutton&url=https%3A%2F%2Fpuzzles.design" target="_blank">
+                <img class="share-images" src="resources/twitter_share.png" />
+              </a></td>
+              <td><a href="https://github.com/iOS10-KIT/UI" target="_blank">
+                <img class="share-images" src="resources/github_share.png" /></a></td>
+              <td><a href="http://www.facebook.com/share.php?u=https://puzzles.design" target="_blank">
+                <img class="share-images" src="resources/facebook_share.png" /></a></td>
+            </tr>
+          </table>
+          <h3>Brought to you by <a href="https://twitter.com/cjmlgrto" target="_blank">Carlos</a>
+             &amp; <a href="https://twitter.com/RamonGilabert" target="_blank">Ramon</a></h3>
         </div>
       </div>
-      <footer>
-        <div id="footer-wrapper">
-          <img class="footer-images" id="footer-image-left"
-          src="resources/music_screen.png" />
-          <img class="footer-images" id="footer-image-right"
-          src="resources/health_screen.png" />
-
-          <div id="credit-container">
-            <table id="share-table">
-              <tr>
-                <td><a href="https://plus.google.com/share?url=https://puzzles.design" target="_blank">
-                  <img class="share-images" src="resources/google_share.png" /></a></td>
-                <td>
-                <a href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fpuzzles.design%2F&ref_src=twsrc%5Etfw&text=Enjoying%20the%20iOS%2010%20UI%20Kit!&tw_p=tweetbutton&url=https%3A%2F%2Fpuzzles.design" target="_blank">
-                  <img class="share-images" src="resources/twitter_share.png" />
-                </a></td>
-                <td><a href="https://github.com/iOS10-KIT/UI" target="_blank">
-                  <img class="share-images" src="resources/github_share.png" /></a></td>
-                <td><a href="http://www.facebook.com/share.php?u=https://puzzles.design" target="_blank">
-                  <img class="share-images" src="resources/facebook_share.png" /></a></td>
-              </tr>
-            </table>
-            <h3>Brought to you by <a href="https://twitter.com/cjmlgrto" target="_blank">Carlos</a>
-               & <a href="https://twitter.com/RamonGilabert" target="_blank">Ramon</a></h3>
-          </div>
-        </div>
-      </footer>
-    </div>
+    </footer>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/index.html
+++ b/index.html
@@ -32,50 +32,49 @@
         system&nbsp;by&nbsp;Apple.</h4>
       <div id="hero-button-container">
         <a id="download-button"
-        href="https://github.com/iOS10-KIT/UI/archive/master.zip">
+        href="https://github.com/iOS10-KIT/UI/archive/master.zip"
+        download="iOS 10 UI Kit.zip">
           <button class="button" id="download-button">Download</button></a>
         <p class="general-text" id="last-updated"><u><a id="last-updated-link" href="https://github.com/iOS10-KIT/UI" target="_blank">Updated</a></u> 16/06/2016</p>
       </div>
     </div>
-    <div id="parallax-container">
-      <div id="parallax-wrapper"></div>
-    </div>
+    <div id="parallax-wrapper"></div>
     <div id="key-points">
       <div id="key-points-table">
-        <div><div>
+        <div>
           <img class="key-point-images" src="resources/icons/symbols_2x.png" />
           <p class="key-point-explanations"><b>Symbols.</b> Every new UI element
             uses Sketch's Symbols for easy customisation and re-use.</p>
-        </div></div>
+        </div>
 
-        <div><div>
+        <div>
           <img class="key-point-images" src="resources/icons/ui_2x.png" />
           <p class="key-point-explanations"><b>All-new UI.</b> Designed pixel-perfect
             to an exhausting amount of detail.</p>
-        </div></div>
+        </div>
 
-        <div><div>
+        <div>
           <img class="key-point-images" src="resources/icons/templates_2x.png" />
           <p class="key-point-explanations"><b>Templates.</b> Start designing for
             iOS 10 with the all-new widgets and notifications templates.</p>
-        </div></div>
+        </div>
 
-        <div><div>
+        <div>
           <img class="key-point-images" src="resources/icons/open_source_2x.png" />
           <p class="key-point-explanations"><b>Open source.</b> Make tweaks and contribute on <a href="https://github.com/iOS10-KIT/UI">GitHub!</a> Let's make this the standard iOS UI kit.</p>
-        </div></div>
+        </div>
 
-        <div><div>
+        <div>
           <img class="key-point-images" src="resources/icons/updates_2x.png" />
           <p class="key-point-explanations"><b>Updates.</b> Keep the kit up-to-date
             as soon as new UI changes appear in iOS 10.</p>
-        </div></div>
+        </div>
 
-        <div><div>
+        <div>
           <img class="key-point-images" src="resources/icons/vectorized_2x.png" />
           <p class="key-point-explanations"><b>Vectorized.</b> Of course, everything
             in the kit is cleanly scalable and resizeable.</p>
-        </div></div>
+        </div>
       </div>
       <footer>
         <div id="footer-wrapper">

--- a/static/style.css
+++ b/static/style.css
@@ -28,22 +28,13 @@ a {
   color: #B0B0B0;
 }
 
-.header {
+#hero-title {
   font-weight: 200;
   letter-spacing: -1px;
   font-size: 95px;
   margin-top: 30px;
   margin-bottom: 0px;
   color: black;
-}
-
-.description {
-  font-weight: 300;
-  font-size: 18px;
-  line-height: 34px;
-  letter-spacing: -0.4px;
-  color: #B0B0B0;
-  margin-top: 0px;
 }
 
 .separator {
@@ -89,6 +80,11 @@ a {
 }
 
 #hero-description {
+  font-weight: 300;
+  font-size: 18px;
+  line-height: 34px;
+  letter-spacing: -0.4px;
+  color: #B0B0B0;
   width: 80vw;
   max-width: 1000px;
   margin: 0 auto;

--- a/static/style.css
+++ b/static/style.css
@@ -5,17 +5,18 @@
 @import url(https://fonts.googleapis.com/css?family=Open+Sans:400,700,600);
 
 * {
-  font-family: -apple-system, 'Helvetica', 'Open Sans', sans-serif;
   box-sizing: border-box;
 }
 
 body {
+  font-family: -apple-system, 'Helvetica', 'Open Sans', sans-serif;
   margin: 0 auto;
   min-height: 100vh;
   max-width: 100vw;
   background: -moz-linear-gradient(top, #FFFFFF 0%, #FEFEFE 75%, #EFEFEF 100%);
   background: -webkit-linear-gradient(top, #FFFFFF 0%, #FEFEFE 75%, #EFEFEF 100%);
   background: linear-gradient(to bottom, #FFFFFF 0%, #FEFEFE 75%, #EFEFEF 100%);
+  text-align: center;
 }
 
 html {
@@ -31,7 +32,6 @@ a {
   font-weight: 200;
   letter-spacing: -1px;
   font-size: 95px;
-  text-align: center;
   margin-top: 30px;
   margin-bottom: 0px;
   color: black;
@@ -43,7 +43,6 @@ a {
   line-height: 34px;
   letter-spacing: -0.4px;
   color: #B0B0B0;
-  text-align: center;
   margin-top: 0px;
 }
 
@@ -51,10 +50,7 @@ a {
   width: 38px;
   height: 3px;
   background-color: #DBDBDB;
-  margin-top: 50px;
-  margin-bottom: 50px;
-  margin-left: 50%;
-  transform: translateX(-50%);
+  margin: 50px auto;
 }
 
 .general-text {
@@ -66,17 +62,16 @@ a {
 .button {
   width: 220px;
   height: 55px;
-  background: none;
+  background: #1B1B1B;
   border: 2px solid #1B1B1B;
   border-radius: 10px;
   color: white;
-  background-color: #1B1B1B;
   font-weight: 500;
   font-size: 16px;
   letter-spacing: 1px;
   text-transform: uppercase;
   cursor: pointer;
-  transition: all 0.3s ease-in;
+  transition: color 0.3s ease-in, background-color 0.3s ease-in;
 }
 
 .button:hover {
@@ -88,10 +83,7 @@ a {
 
 #hero-header {
   position: relative;
-  background-image: url("../resources/header_full.jpg");
-  background-size: 150vw;
-  background-repeat: no-repeat;
-  background-position: 50% 100%;
+  background: url("../resources/header_full.jpg") no-repeat 50% 100% / 150vw;
   width: 100vw;
   height: 70vh;
 }
@@ -99,14 +91,11 @@ a {
 #hero-description {
   width: 80vw;
   max-width: 1000px;
-  margin-left: 50%;
-  transform: translateX(-50%);
+  margin: 0 auto;
 }
 
 #hero-button-container {
-  text-align: center;
-  margin-top: 70px;
-  margin-bottom: 70px;
+  margin: 70px auto;
 }
 
 #hero-button-container #last-updated {
@@ -124,45 +113,27 @@ a {
 
 /* Parallax */
 
-#parallax-container {
-  position: relative;
+#parallax-wrapper {
+  background: url("../resources/header_full.jpg") no-repeat center / 150vw;
   width: 100vw;
   height: 475px;
 }
 
-#parallax-wrapper {
-  position: absolute;
-  background-image: url("../resources/header_full.jpg");
-  background-size: 150vw;
-  background-repeat: no-repeat;
-  background-position: center;
-  width: 100%;
-  height: 100%;
-}
-
 /* Key points */
-
-#key-points {
-  text-align: center;
-}
 
 #key-points-table {
   position: relative;
   width: 100%;
   max-width: 1000px;
-  margin-top: 80px;
-  margin-bottom: 0px;
-  margin-left: 50%;
-  transform: translateX(-50%);
+  margin: 80px auto 0 auto;
   overflow: hidden;
 }
 
 #key-points-table div {
   display: inline-block;
-  float: center;
-  text-align: center;
   width: 33%;
   overflow: hidden;
+  vertical-align: top;
 }
 
 #key-points-table div div {
@@ -173,8 +144,6 @@ a {
   width: 154px;
   height: 154px;
   margin: 0 auto;
-  margin-left: 50%;
-  transform: translateX(-50%);
 }
 
 .key-point-explanations {
@@ -183,11 +152,7 @@ a {
   letter-spacing: 0.35px;
   line-height: 25px;
   width: 80%;
-  text-align: center;
-  margin-top: 0px;
-  margin-bottom: 40px;
-  margin-left: 50%;
-  transform: translateX(-50%);
+  margin: 0 auto 40px auto;
   white-space: normal;
 }
 
@@ -195,7 +160,6 @@ a {
 
 footer {
   margin-top: 10px;
-  text-align: center;
 }
 
 #footer-wrapper {
@@ -204,10 +168,8 @@ footer {
   height: 600px;
   max-width: 1300px;
   overflow: hidden;
-  margin: 0;
+  margin: 0 auto;
   padding: 0;
-  margin-left: 50%;
-  transform: translateX(-50%);
 }
 
 .footer-images {
@@ -227,8 +189,7 @@ footer {
 }
 
 #credit-container {
-  margin-top: 300px;
-  transform: translateY(-50%);
+  margin-top: 250px;
 }
 
 #credit-container h3 {
@@ -253,7 +214,7 @@ footer {
   bottom: -2px;
   background: #4A4A4A;
   height: 1px;
-  transition: all 0.3s ease-in;
+  transition: left 0.3s ease-in, right 0.3s ease-in;
 }
 
 #credit-container h3 a:hover:after {
@@ -262,12 +223,11 @@ footer {
 }
 
 #share-table {
-  margin-left: 50%;
-  transform: translateX(-50%);
+  margin: 0 auto;
 }
 
 #share-table tr td a img {
-  transition: all 0.15s ease-in;
+  transition: transform 0.15s ease-in;
 }
 
 #share-table tr td a img:hover {
@@ -280,19 +240,11 @@ footer {
 }
 
 @media (max-width: 1000px) {
-  #hero-header {
+  #hero-header, #parallax-wrapper {
     background-size: 1440px;
   }
 
-  #parallax-wrapper {
-    background-size: 1440px;
-  }
-
-  #footer-image-left {
-    visibility: hidden;
-  }
-
-  #footer-image-right {
+  #footer-image-left, #footer-image-right {
     visibility: hidden;
   }
 
@@ -310,8 +262,7 @@ footer {
   }
 
   .key-point-images {
-    margin-left: 0%;
-    transform: translateX(0);
+    margin: 0 auto;
   }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -4,23 +4,14 @@
 
 @import url(https://fonts.googleapis.com/css?family=Open+Sans:400,700,600);
 
-* {
-  box-sizing: border-box;
-}
-
 body {
-  font-family: -apple-system, 'Helvetica', 'Open Sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Helvetica', 'Open Sans', sans-serif;
   margin: 0 auto;
   min-height: 100vh;
-  max-width: 100vw;
   background: -moz-linear-gradient(top, #FFFFFF 0%, #FEFEFE 75%, #EFEFEF 100%);
   background: -webkit-linear-gradient(top, #FFFFFF 0%, #FEFEFE 75%, #EFEFEF 100%);
   background: linear-gradient(to bottom, #FFFFFF 0%, #FEFEFE 75%, #EFEFEF 100%);
   text-align: center;
-}
-
-html {
-  max-width: 100vw;
 }
 
 a {

--- a/static/style.css
+++ b/static/style.css
@@ -32,8 +32,7 @@ a {
   font-weight: 200;
   letter-spacing: -1px;
   font-size: 95px;
-  margin-top: 30px;
-  margin-bottom: 0px;
+  margin: 30px 0 0;
   color: black;
 }
 
@@ -175,13 +174,13 @@ footer {
 #footer-image-left {
   position: absolute;
   top: 10px;
-  left: 0px;
+  left: 0;
 }
 
 #footer-image-right {
   position: absolute;
   top: 200px;
-  right: 0px;
+  right: 0;
 }
 
 #credit-container {
@@ -214,8 +213,8 @@ footer {
 }
 
 #credit-container h3 a:hover:after {
-  left: 0%;
-  right: 0%;
+  left: 0;
+  right: 0;
 }
 
 #share-table {
@@ -292,6 +291,6 @@ footer {
 
   #credit-container h3 {
     font-size: 13px;
-    margin-top: 0px;
+    margin-top: 0;
   }
 }


### PR DESCRIPTION
The commit messages explain much more of what changed, but basically it's just an overall tidy of HTML elements and CSS that isn't needed (e.g. many transforms that could be replaced by a simpler/faster `margin: ..` statement, nested `div`s that weren't needed) which reduces the size of the files a bit, and could speed up page rendering in terms of CSS.

Also fixed a larger bug that meant Chrome on OSX wouldn't use the system font, as a separate font family is needed for Blink now (`BlinkMacSystemFont`).
